### PR TITLE
Prototype yoke control

### DIFF
--- a/scripts/tools/register_device.py
+++ b/scripts/tools/register_device.py
@@ -1,0 +1,101 @@
+__author__ = 'luis'
+
+import logging
+logging.basicConfig(level=logging.INFO)
+import traceback
+from optparse import OptionParser
+import subprocess
+import json
+import os
+import glob
+from ethoscope.web_utils.helpers import get_machine_id
+logging.basicConfig(level=logging.INFO)
+
+#from bottle import Bottle, ServerAdapter, request, server_names
+
+import socket
+from zeroconf import ServiceInfo, Zeroconf
+
+PORT=9000
+
+def main():
+
+    try:
+        # Register the ethoscope using zeroconf so that the node knows about it.
+        # I need an address to register the service, but I don't understand which one (different
+        # interfaces will have different addresses). The python module zeroconf fails if I don't
+        # provide one, and the way it gets supplied doesn't appear to be IPv6 compatible. I'll put
+        # in whatever I get from "gethostbyname" but not trust that in the code on the node side.
+
+
+        # we include the machine-id together with the hostname to make sure each device is really unique
+        # moreover, we will burn the ETHOSCOPE_000 img with a non existing /etc/machine-id file
+        # to make sure each burned image will get a unique machine-id at the first boot
+
+        hostname = socket.gethostname()
+        uid = "%s-%s" % ( hostname, get_machine_id() )
+
+
+        logging.warning("Waiting for a network connection")
+        address = False
+        while address is False:
+            try:
+                #address = socket.gethostbyname(hostname+".local")
+                address = socket.gethostbyname(hostname)
+                #this returns something like '192.168.1.4' - when both connected, ethernet IP has priority over wifi IP
+            except:
+                pass
+                #address = socket.gethostbyname(hostname)
+                #this returns '127.0.1.1' and it is useless
+
+        logging.info(f"Registering service at PORT {PORT}")
+        serviceInfo = ServiceInfo("_ethoscope._tcp.local.",
+                        uid + "._ethoscope._tcp.local.",
+                        address = socket.inet_aton(address),
+                        port = PORT,
+                        properties = {
+                            'version': '0.0.1',
+                            'id_page': '/id',
+                            'user_options_page': '/user_options',
+                            'static_page': '/static',
+                            'controls_page': '/controls',
+                            'user_options_page': '/user_options'
+                        } )
+        zeroconf = Zeroconf()
+        zeroconf.register_service(serviceInfo)
+        logging.info('Device registered')
+
+    except OSError as e:
+        logging.error(e)
+        logging.error(traceback.format_exc())
+        for i in range(9):
+            time.sleep(10)
+            return main()
+
+    except Exception as e:
+        try:
+            logging.info('Device not registered')
+            logging.error(e)
+            logging.error(traceback.format_exc())
+            zeroconf.unregister_service(serviceInfo)
+            zeroconf.close()
+        except Exception:
+            pass
+
+        close(1)
+
+    finally:
+        try:
+            zeroconf.unregister_service(serviceInfo)
+            zeroconf.close()
+        except:
+            pass
+        close()
+
+
+def close(exit_status=0):
+    os._exit(exit_status)
+
+
+
+main()

--- a/src/ethoscope/core/monitor.py
+++ b/src/ethoscope/core/monitor.py
@@ -96,6 +96,11 @@ class Monitor(DescribedObject):
                         tracker=self._unit_trackers[ff-1]._tracker,
                         **kwargs)
                 
+                # finally, if a region id is neither yoke nor focal, assume focal
+                for i, ut in enumerate(self._unit_trackers):
+                    if ut is None:
+                        self._unit_trackers[i] = TrackingUnit(tracker_class, rois[i], stimulators[i], *args, **kwargs)
+
                 assert all([not ut._tracker is None for ut in self._unit_trackers])
 
         else:

--- a/src/ethoscope/core/monitor.py
+++ b/src/ethoscope/core/monitor.py
@@ -69,10 +69,10 @@ class Monitor(DescribedObject):
             self._unit_trackers = [TrackingUnit(tracker_class, r, None, *args, **kwargs) for r in rois]
 
         elif len(stimulators) == len(rois):
-            if yoke is None:
+            # if the user does not enter anything in yoke, yoke becomes "" (not None)
+            if yoke is None or yoke == "":
                 self._unit_trackers = [TrackingUnit(tracker_class, r, inter, *args, **kwargs) for r, inter in zip(rois, stimulators)]
             else:
-
                 yoke = json.loads(yoke)
                 self._unit_trackers = [None for r in rois]
                 for f in yoke.values():

--- a/src/ethoscope/core/monitor.py
+++ b/src/ethoscope/core/monitor.py
@@ -26,7 +26,7 @@ class Monitor(DescribedObject):
                                    
     def __init__(self, camera, tracker_class,
                  rois = None, stimulators=None,
-                 yoke=None
+                 yoke=None,
                  *args, **kwargs  # extra arguments for the tracker objects
                  ):
         r"""

--- a/src/ethoscope/core/tracking_unit.py
+++ b/src/ethoscope/core/tracking_unit.py
@@ -5,7 +5,7 @@ from ethoscope.stimulators.stimulators import DefaultStimulator
 
 
 class TrackingUnit(object):
-    def __init__(self, tracking_class, roi, stimulator=None, *args, **kwargs):
+    def __init__(self, tracking_class, roi, stimulator=None, tracker=None, *args, **kwargs):
         r"""
         Class instantiating a tracker(:class:`~ethoscope.trackers.trackers.BaseTracker`),
         and linking it with an individual ROI(:class:`~ethoscope.rois.roi_builders.ROI`) and
@@ -30,7 +30,10 @@ class TrackingUnit(object):
         else:
             self._stimulator = DefaultStimulator(None)
 
-        self._stimulator.bind_tracker(self._tracker)
+        if tracker is None:
+            self._stimulator.bind_tracker(self._tracker)
+        else:
+            self._stimulator.bind_tracker(tracker)
 
 
     @property

--- a/src/ethoscope/core/tracking_unit.py
+++ b/src/ethoscope/core/tracking_unit.py
@@ -1,4 +1,6 @@
 __author__ = 'quentin'
+
+import logging
 from ethoscope.core.variables import BaseRelativeVariable
 from ethoscope.core.data_point import DataPoint
 from ethoscope.stimulators.stimulators import DefaultStimulator
@@ -32,8 +34,13 @@ class TrackingUnit(object):
 
         if tracker is None:
             self._stimulator.bind_tracker(self._tracker)
+            self._stimulator.target_roi = None
         else:
             self._stimulator.bind_tracker(tracker)
+            self._stimulator.target_roi = self._tracker._roi.idx
+
+        logging.info(f"Tracking unit from ROI {self._tracker._roi.idx} bounded tracker from ROI {self._stimulator._tracker._roi.idx} to its stimulator")
+        logging.info(f"The tracking data of this unit will reflect the behavior of the animal in ROI {self._tracker._roi.idx} but the stimulator responds to the behavior in ROI {self._stimulator._tracker._roi.idx}")
 
 
     @property
@@ -97,6 +104,7 @@ class TrackingUnit(object):
         data_rows = self._tracker.track(t,img)
 
         interact, result = self._stimulator.apply()
+
         if len(data_rows) == 0:
             return []
 

--- a/src/ethoscope/hardware/interfaces/optomotor.py
+++ b/src/ethoscope/hardware/interfaces/optomotor.py
@@ -91,6 +91,7 @@ class OptoMotor(BaseInterface):
         duration = int(duration)
         intensity= int(intensity)
         instruction = b"P %i %i %i\r\n" % (channel, duration, intensity)
+        logging.info(instruction)
         o = self._serial.write(instruction)
         return o
 

--- a/src/ethoscope/stimulators/sleep_depriver_stimulators.py
+++ b/src/ethoscope/stimulators/sleep_depriver_stimulators.py
@@ -111,7 +111,11 @@ class SleepDepStimulator(IsMovingStimulator):
 
 
     def _decide(self):
-        roi_id= self._tracker._roi.idx
+        if getattr(self, "target_roi", False):
+            roi_id = self.target_roi
+        else:
+            roi_id= self._tracker._roi.idx
+
         now =  self._tracker.last_time_point
 
         try:
@@ -129,6 +133,7 @@ class SleepDepStimulator(IsMovingStimulator):
             if float(now - self._t0) > self._inactivity_time_threshold_ms:
                 self._t0 = None
                 return HasInteractedVariable(True), {"channel":channel}
+
         else:
             self._t0 = now
         return HasInteractedVariable(False), {}
@@ -224,7 +229,6 @@ class OptomotorSleepDepriver(SleepDepStimulator):
         dic["duration"] = self._pulse_duration
         dic["intensity"] = self._pulse_intensity	
         return out,dic
-
 
 
 class ExperimentalSleepDepStimulator(SleepDepStimulator):

--- a/src/ethoscope/stimulators/stimulators.py
+++ b/src/ethoscope/stimulators/stimulators.py
@@ -54,6 +54,7 @@ class   BaseStimulator(DescribedObject):
         if self._scheduler.check_time_range() is False:
             return HasInteractedVariable(False) , {}
         interact, result  = self._decide()
+
         if interact > 0:
             self._deliver(**result)
 

--- a/src/ethoscope/utils/io.py
+++ b/src/ethoscope/utils/io.py
@@ -478,7 +478,7 @@ class ResultWriter(object):
 
 
         logging.info("Creating 'METADATA' table")
-        self._create_table("METADATA", "field CHAR(100), value VARCHAR(3000)")
+        self._create_table("METADATA", "field CHAR(100), value VARCHAR(4000)")
 
         logging.info("Creating 'START_EVENTS' table")
         self._create_table("START_EVENTS", "id INT  NOT NULL AUTO_INCREMENT PRIMARY KEY, t INT, event CHAR(100)")

--- a/src/ethoscope/web_utils/control_thread.py
+++ b/src/ethoscope/web_utils/control_thread.py
@@ -426,7 +426,7 @@ class ControlThread(Thread):
 
         return  (cam, rw, rois, TrackerClass, tracker_kwargs,
                         hardware_connection, StimulatorClass, stimulator_kwargs,
-                        monitorClass, monitor_kwargs)
+                        MonitorClass, monitor_kwargs)
 
     def run(self):
         cam = None


### PR DESCRIPTION
First prototype of yoke control. Users can now pass a yoke:focal mapping in the GUI by entering a string with the following format in the `yoke` option of the monitor, as follows

```
{"12": 1}
```

This has the effect of making the stimulator assigned to ROI 12 to follow the behavior of ROI 1 